### PR TITLE
87 sort by creation/update time not present for analyses

### DIFF
--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -3,3 +3,13 @@
     width: 100%;
     justify-content: space-between;
 }
+
+.search-bar {
+    display: flex;
+    width: 50%;
+    justify-content: left;
+}
+
+.search-text-bar {
+    margin-right: 10px;
+}

--- a/components/analysis/AnalysesTable.vue
+++ b/components/analysis/AnalysesTable.vue
@@ -5,18 +5,11 @@ import TableRowMetadata from "~/components/TableRowMetadata.vue";
 import ExpandRowButtons from "~/components/table/ExpandRowButtons.vue";
 import { showHubAdapterConnectionErrorToast } from "~/composables/connectionErrorToast";
 import { FilterMatchMode } from "primevue/api";
-import type { AnalysisNode } from "~/services/Api";
 
 const expandedRows = ref();
 const analyses = ref();
 
-const expandRowEntries = [
-  "id",
-  "project_id",
-  "node_id",
-  "created_at",
-  "updated_at",
-];
+const expandRowEntries = ["project_id", "node_id", "created_at", "updated_at"];
 
 const filters = ref({
   global: { value: null, matchMode: FilterMatchMode.CONTAINS },
@@ -30,16 +23,11 @@ const filters = ref({
 const { data: response, status, error } = await getAnalysisNodes();
 
 if (status.value === "success") {
-  const formattedData = formatDataRow(
+  analyses.value = formatDataRow(
     response.value!.data,
     ["created_at", "updated_at"],
     expandRowEntries,
   );
-
-  analyses.value = formattedData.map((analysisNode: AnalysisNode) => ({
-    ...analysisNode,
-    uniqueId: analysisNode.analysis_id + "-" + analysisNode.node.id,
-  }));
 } else if (error.value?.statusCode === 500) {
   showHubAdapterConnectionErrorToast();
 }
@@ -58,7 +46,7 @@ function onToggleRowExpansion(rowIds) {
         <DataTable
           :value="analyses"
           v-model:expandedRows="expandedRows"
-          dataKey="uniqueId"
+          dataKey="id"
           :pt="{
             table: 'table table-striped',
           }"
@@ -91,7 +79,7 @@ function onToggleRowExpansion(rowIds) {
               <div class="expand-buttons">
                 <ExpandRowButtons
                   :rows="analyses"
-                  :uniqueId="'uniqueId'"
+                  :uniqueId="'id'"
                   @expandedRowList="onToggleRowExpansion"
                 />
               </div>

--- a/components/analysis/AnalysesTable.vue
+++ b/components/analysis/AnalysesTable.vue
@@ -5,20 +5,12 @@ import TableRowMetadata from "~/components/TableRowMetadata.vue";
 import ExpandRowButtons from "~/components/table/ExpandRowButtons.vue";
 import { showHubAdapterConnectionErrorToast } from "~/composables/connectionErrorToast";
 import { FilterMatchMode } from "primevue/api";
+import SearchBar from "~/components/table/SearchBar.vue";
 
 const expandedRows = ref();
 const analyses = ref();
 
 const expandRowEntries = ["project_id", "node_id", "created_at", "updated_at"];
-
-const filters = ref({
-  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-  // Below are more examples
-  // "analysis.name": { value: null, matchMode: FilterMatchMode.CONTAINS },
-  // status: { value: null, matchMode: FilterMatchMode.CONTAINS },
-  // verified: { value: null, matchMode: FilterMatchMode.EQUALS },
-  // name: { value: null, matchMode: FilterMatchMode.STARTS_WITH },
-});
 
 const { data: response, status, error } = await getAnalysisNodes();
 
@@ -35,6 +27,32 @@ if (status.value === "success") {
 function onToggleRowExpansion(rowIds) {
   expandedRows.value = rowIds;
 }
+
+// Table filters
+const defaultFilters = {
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+  // Below are more examples
+  // "analysis.name": { value: null, matchMode: FilterMatchMode.CONTAINS },
+  // status: { value: null, matchMode: FilterMatchMode.CONTAINS },
+  // verified: { value: null, matchMode: FilterMatchMode.EQUALS },
+  // name: { value: null, matchMode: FilterMatchMode.STARTS_WITH },
+};
+const filters = ref(defaultFilters);
+
+function resetFilters() {
+  const clearedFilters = {};
+  for (const filterKey in defaultFilters) {
+    clearedFilters[filterKey] = {
+      ...defaultFilters[filterKey],
+    };
+    clearedFilters[filterKey].value = null;
+  }
+  filters.value = clearedFilters;
+}
+
+const updateFilters = (filterText: string) => {
+  filters.value.global.value = filterText;
+};
 </script>
 
 <template>
@@ -65,17 +83,11 @@ function onToggleRowExpansion(rowIds) {
           <template #empty> No analyses found. </template>
           <template #header>
             <div class="table-header-row">
-              <div class="flex justify-content-end search-bar">
-                <IconField iconPosition="left">
-                  <InputIcon>
-                    <i class="pi pi-search" />
-                  </InputIcon>
-                  <InputText
-                    v-model="filters['global'].value"
-                    placeholder="Keyword Search"
-                  />
-                </IconField>
-              </div>
+              <SearchBar
+                :searchTerm="defaultFilters.global.value"
+                @clearFilters="resetFilters"
+                @updateSearch="updateFilters"
+              />
               <div class="expand-buttons">
                 <ExpandRowButtons
                   :rows="analyses"

--- a/components/analysis/AnalysesTable.vue
+++ b/components/analysis/AnalysesTable.vue
@@ -10,7 +10,7 @@ import SearchBar from "~/components/table/SearchBar.vue";
 const expandedRows = ref();
 const analyses = ref();
 
-const expandRowEntries = ["project_id", "node_id", "created_at", "updated_at"];
+const expandRowEntries = ["project_id", "node_id"];
 
 const { data: response, status, error } = await getAnalysisNodes();
 
@@ -119,6 +119,32 @@ const updateFilters = (filterText: string) => {
             header="Project"
             :sortable="true"
           />
+          <Column
+            header="Created On"
+            field="created_at.long"
+            filterField="created_at.date"
+            dataType="date"
+            :sortable="true"
+          >
+            <template #body="{ data }">
+              <p v-tooltip.top="data.created_at.long">
+                {{ data.created_at.short }}
+              </p>
+            </template>
+          </Column>
+          <Column
+            header="Last Updated"
+            field="updated_at.long"
+            filterField="updated_at.date"
+            dataType="date"
+            :sortable="true"
+          >
+            <template #body="{ data }">
+              <p v-tooltip.top="data.updated_at.long">
+                {{ data.updated_at.short }}
+              </p>
+            </template>
+          </Column>
           <Column field="node.name" header="Node" :sortable="true" />
           <Column
             field="expand.id"

--- a/components/data-stores/tables/DetailedAnalysisTable.vue
+++ b/components/data-stores/tables/DetailedAnalysisTable.vue
@@ -196,8 +196,10 @@ const updateFilters = (filterText: string) => {
       ></Column>
       <Column
         header="Created On"
+        field="kongProjCreatedAt.long"
         filterField="kongAnalysisCreatedAt.long"
         dataType="date"
+        :sortable="true"
       >
         <template #body="{ data }">
           <p v-tooltip.top="data.kongAnalysisCreatedAt.long">

--- a/components/data-stores/tables/DetailedDataStoreTable.vue
+++ b/components/data-stores/tables/DetailedDataStoreTable.vue
@@ -104,19 +104,36 @@ const updateFilters = (filterText: string) => {
           />
         </div>
       </template>
-      <Column field="name" header="Name" :sortable="true"></Column>
+      <Column
+        field="name"
+        header="Name"
+        :sortable="true"
+        style="width: 30rem"
+      ></Column>
       <Column field="path" header="Path"></Column>
       <Column field="host" header="Host" :sortable="true"></Column>
       <Column field="port" header="Port"></Column>
       <Column field="protocol" header="Protocol" :sortable="true"></Column>
-      <Column header="Created On" filterField="created_at.long" dataType="date">
+      <Column
+        header="Created On"
+        field="created_at.long"
+        filterField="created_at.date"
+        dataType="date"
+        :sortable="true"
+      >
         <template #body="{ data }">
           <p v-tooltip.top="data.created_at.long">
             {{ data.created_at.short }}
           </p>
         </template>
       </Column>
-      <Column header="Last Updated" filterField="date" dataType="date">
+      <Column
+        header="Last Updated"
+        field="updated_at.long"
+        filterField="updated_at.date"
+        dataType="date"
+        :sortable="true"
+      >
         <template #body="{ data }">
           <p v-tooltip.top="data.updated_at.long">
             {{ data.updated_at.short }}

--- a/components/data-stores/tables/DetailedDataStoreTable.vue
+++ b/components/data-stores/tables/DetailedDataStoreTable.vue
@@ -3,6 +3,7 @@ import { deleteDataStore } from "~/composables/useAPIFetch";
 import { useConfirm } from "primevue/useconfirm";
 import type { DetailedService } from "~/services/Api";
 import { FilterMatchMode } from "primevue/api";
+import SearchBar from "~/components/table/SearchBar.vue";
 
 const props = defineProps({
   stores: Array<DetailedService>,
@@ -13,10 +14,6 @@ const dataStores = ref(props.stores);
 const confirm = useConfirm();
 const toast = useToast();
 const deleteLoading = ref(false);
-
-const filters = ref({
-  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-});
 
 async function onConfirmDeleteDataStore(dsName: string) {
   deleteLoading.value = true;
@@ -58,6 +55,30 @@ const confirmDelete = (event, dsName: string) => {
     reject: () => {},
   });
 };
+
+// Table filters
+const defaultFilters = {
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+  "created_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
+  "updated_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
+};
+
+const filters = ref(defaultFilters);
+
+function resetFilters() {
+  const clearedFilters = {};
+  for (const filterKey in defaultFilters) {
+    clearedFilters[filterKey] = {
+      ...defaultFilters[filterKey],
+    };
+    clearedFilters[filterKey].value = null;
+  }
+  filters.value = clearedFilters;
+}
+
+const updateFilters = (filterText: string) => {
+  filters.value.global.value = filterText;
+};
 </script>
 
 <template>
@@ -76,17 +97,11 @@ const confirmDelete = (event, dsName: string) => {
       <template #empty> No data stores found. </template>
       <template #header>
         <div class="table-header-row">
-          <div class="flex justify-content-end search-bar">
-            <IconField iconPosition="left">
-              <InputIcon>
-                <i class="pi pi-search" />
-              </InputIcon>
-              <InputText
-                v-model="filters['global'].value"
-                placeholder="Keyword Search"
-              />
-            </IconField>
-          </div>
+          <SearchBar
+            :searchTerm="defaultFilters.global.value"
+            @clearFilters="resetFilters"
+            @updateSearch="updateFilters"
+          />
         </div>
       </template>
       <Column field="name" header="Name" :sortable="true"></Column>
@@ -94,12 +109,20 @@ const confirmDelete = (event, dsName: string) => {
       <Column field="host" header="Host" :sortable="true"></Column>
       <Column field="port" header="Port"></Column>
       <Column field="protocol" header="Protocol" :sortable="true"></Column>
-      <Column field="created_at" header="Created" :sortable="true"></Column>
-      <Column
-        field="updated_at"
-        header="Last Updated"
-        :sortable="true"
-      ></Column>
+      <Column header="Created On" filterField="created_at.long" dataType="date">
+        <template #body="{ data }">
+          <p v-tooltip.top="data.created_at.long">
+            {{ data.created_at.short }}
+          </p>
+        </template>
+      </Column>
+      <Column header="Last Updated" filterField="date" dataType="date">
+        <template #body="{ data }">
+          <p v-tooltip.top="data.updated_at.long">
+            {{ data.updated_at.short }}
+          </p>
+        </template>
+      </Column>
       <Column field="name" header="Delete?" :exportable="false">
         <template #body="slotProps">
           <ConfirmPopup group="templating">

--- a/components/data-stores/tables/DetailedProjectTable.vue
+++ b/components/data-stores/tables/DetailedProjectTable.vue
@@ -160,8 +160,10 @@ const updateFilters = (filterText: string) => {
       <Column field="dataStore" header="Data Store" :sortable="true"></Column>
       <Column
         header="Created On"
-        filterField="kongProjCreatedAt.short"
+        field="kongProjCreatedAt.long"
+        filterField="kongProjCreatedAt.date"
         dataType="date"
+        :sortable="true"
       >
         <template #body="{ data }">
           <p v-tooltip.top="data.kongProjCreatedAt.long">
@@ -171,8 +173,10 @@ const updateFilters = (filterText: string) => {
       </Column>
       <Column
         header="Last Updated"
-        filterField="kongProjUpdatedAt.short"
+        field="kongProjUpdatedAt.long"
+        filterField="kongProjUpdatedAt.date"
         dataType="date"
+        :sortable="true"
       >
         <template #body="{ data }">
           <p v-tooltip.top="data.kongProjUpdatedAt.long">

--- a/components/data-stores/tables/DetailedProjectTable.vue
+++ b/components/data-stores/tables/DetailedProjectTable.vue
@@ -4,6 +4,7 @@ import { useConfirm } from "primevue/useconfirm";
 import type { DetailedService, Route } from "~/services/Api";
 import { extractUuid } from "~/utils/extract-uuid-from-kong-username";
 import { FilterMatchMode } from "primevue/api";
+import SearchBar from "~/components/table/SearchBar.vue";
 
 const props = defineProps({
   detailedStoreList: Array<DetailedService>,
@@ -24,10 +25,6 @@ const projectTable = ref();
 const toast = useToast();
 const confirm = useConfirm();
 const loading = ref(false);
-
-const filters = ref({
-  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-});
 
 onMounted(() => {
   meltDataStoreTable();
@@ -102,6 +99,30 @@ function meltDataStoreTable() {
   }
   projectTable.value = elongatedTableRows;
 }
+
+// Table filters
+const defaultFilters = {
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+  "created_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
+  "updated_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
+};
+
+const filters = ref(defaultFilters);
+
+function resetFilters() {
+  const clearedFilters = {};
+  for (const filterKey in defaultFilters) {
+    clearedFilters[filterKey] = {
+      ...defaultFilters[filterKey],
+    };
+    clearedFilters[filterKey].value = null;
+  }
+  filters.value = clearedFilters;
+}
+
+const updateFilters = (filterText: string) => {
+  filters.value.global.value = filterText;
+};
 </script>
 
 <template>
@@ -119,17 +140,11 @@ function meltDataStoreTable() {
       <template #empty> No associated projects found.</template>
       <template #header>
         <div class="table-header-row">
-          <div class="flex justify-content-end search-bar">
-            <IconField iconPosition="left">
-              <InputIcon>
-                <i class="pi pi-search" />
-              </InputIcon>
-              <InputText
-                v-model="filters['global'].value"
-                placeholder="Keyword Search"
-              />
-            </IconField>
-          </div>
+          <SearchBar
+            :searchTerm="defaultFilters.global.value"
+            @clearFilters="resetFilters"
+            @updateSearch="updateFilters"
+          />
         </div>
       </template>
       <Column
@@ -144,15 +159,27 @@ function meltDataStoreTable() {
       ></Column>
       <Column field="dataStore" header="Data Store" :sortable="true"></Column>
       <Column
-        field="kongProjCreatedAt"
-        header="Created"
-        :sortable="true"
-      ></Column>
+        header="Created On"
+        filterField="kongProjCreatedAt.short"
+        dataType="date"
+      >
+        <template #body="{ data }">
+          <p v-tooltip.top="data.kongProjCreatedAt.long">
+            {{ data.kongProjCreatedAt.short }}
+          </p>
+        </template>
+      </Column>
       <Column
-        field="kongProjUpdatedAt"
         header="Last Updated"
-        :sortable="true"
-      ></Column>
+        filterField="kongProjUpdatedAt.short"
+        dataType="date"
+      >
+        <template #body="{ data }">
+          <p v-tooltip.top="data.kongProjUpdatedAt.long">
+            {{ data.kongProjUpdatedAt.short }}
+          </p>
+        </template>
+      </Column>
       <Column field="projectId" header="Disconnect?" :exportable="false">
         <template #body="slotProps">
           <ConfirmPopup group="templating">

--- a/components/projects/ProjectTable.vue
+++ b/components/projects/ProjectTable.vue
@@ -25,8 +25,11 @@ if (status.value === "success") {
 // Table filters
 const defaultFilters = {
   global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-  "created_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
-  "updated_at.short": { value: null, matchMode: FilterMatchMode.DATE_IS },
+  "created_at.date": {
+    value: null,
+    matchMode: FilterMatchMode.DATE_IS | FilterMatchMode.DATE_BEFORE,
+  },
+  "updated_at.date": { value: null, matchMode: FilterMatchMode.DATE_IS },
 };
 
 const filters = ref(defaultFilters);
@@ -72,27 +75,39 @@ const updateFilters = (filterText: string) => {
               />
             </div>
           </template>
-          <Column field="name" header="Name" :sortable="true"></Column>
+          <Column
+            field="name"
+            header="Name"
+            :sortable="true"
+            style="width: 30rem"
+          ></Column>
           <Column
             header="Created On"
-            filterField="created_at.long"
+            field="created_at.long"
+            filterField="created_at.date"
             dataType="date"
+            :sortable="true"
           >
             <template #body="{ data }">
               <p v-tooltip.top="data.created_at.long">
                 {{ data.created_at.short }}
               </p>
             </template>
-            <template #filter="{ filterModel }">
-              <Calendar
-                v-model="filterModel.value"
-                dateFormat="dd.mm.yyyy"
-                placeholder="dd.mm.yyyy"
-                mask="99/99/9999"
-              />
-            </template>
+            <!--            <template #filter="{ filterModel }">-->
+            <!--              <Calendar-->
+            <!--                v-model="filterModel.value"-->
+            <!--                dateFormat="dd.mm.yyyy"-->
+            <!--                placeholder="dd.mm.yyyy"-->
+            <!--              />-->
+            <!--            </template>-->
           </Column>
-          <Column header="Last Updated" filterField="date" dataType="date">
+          <Column
+            header="Last Updated"
+            field="updated_at.long"
+            filterField="updated_at.date"
+            dataType="date"
+            :sortable="true"
+          >
             <template #body="{ data }">
               <p v-tooltip.top="data.updated_at.long">
                 {{ data.updated_at.short }}

--- a/components/projects/ProposalTable.vue
+++ b/components/projects/ProposalTable.vue
@@ -110,8 +110,10 @@ const updateFilters = (filterText: string) => {
           ></Column>
           <Column
             header="Created On"
-            filterField="created_at.long"
+            field="created_at.long"
+            filterField="created_at.date"
             dataType="date"
+            :sortable="true"
           >
             <template #body="{ data }">
               <p v-tooltip.top="data.created_at.long">
@@ -119,7 +121,13 @@ const updateFilters = (filterText: string) => {
               </p>
             </template>
           </Column>
-          <Column header="Last Updated" filterField="date" dataType="date">
+          <Column
+            header="Last Updated"
+            field="updated_at.long"
+            filterField="updated_at.date"
+            dataType="date"
+            :sortable="true"
+          >
             <template #body="{ data }">
               <p v-tooltip.top="data.updated_at.long">
                 {{ data.updated_at.short }}

--- a/components/projects/ProposalTable.vue
+++ b/components/projects/ProposalTable.vue
@@ -7,16 +7,13 @@ import type { ProjectNode } from "~/services/Api";
 import ExpandRowButtons from "~/components/table/ExpandRowButtons.vue";
 import { showHubAdapterConnectionErrorToast } from "~/composables/connectionErrorToast";
 import { FilterMatchMode } from "primevue/api";
+import SearchBar from "~/components/table/SearchBar.vue";
 
 const proposals = ref();
 const expandedRows = ref({});
 
 const dataRowUnixCols = ["created_at", "updated_at"];
 const expandRowEntries = ["project_id", "node_id"];
-
-const filters = ref({
-  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
-});
 
 const { data: response, status, error } = await getProposals();
 if (status.value === "success") {
@@ -41,6 +38,27 @@ function updateTable(newData: ProjectNode) {
     }
   }
 }
+
+// Table filters
+const defaultFilters = {
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+};
+const filters = ref(defaultFilters);
+
+function resetFilters() {
+  const clearedFilters = {};
+  for (const filterKey in defaultFilters) {
+    clearedFilters[filterKey] = {
+      ...defaultFilters[filterKey],
+    };
+    clearedFilters[filterKey].value = null;
+  }
+  filters.value = clearedFilters;
+}
+
+const updateFilters = (filterText: string) => {
+  filters.value.global.value = filterText;
+};
 </script>
 
 <template>
@@ -63,17 +81,11 @@ function updateTable(newData: ProjectNode) {
           <template #empty> No proposals found. </template>
           <template #header>
             <div class="table-header-row">
-              <div class="flex justify-content-end search-bar">
-                <IconField iconPosition="left">
-                  <InputIcon>
-                    <i class="pi pi-search" />
-                  </InputIcon>
-                  <InputText
-                    v-model="filters['global'].value"
-                    placeholder="Keyword Search"
-                  />
-                </IconField>
-              </div>
+              <SearchBar
+                :searchTerm="defaultFilters.global.value"
+                @clearFilters="resetFilters"
+                @updateSearch="updateFilters"
+              />
               <div class="expand-buttons">
                 <ExpandRowButtons
                   :rows="proposals"
@@ -96,13 +108,24 @@ function updateTable(newData: ProjectNode) {
             header="Approval Status"
             :sortable="true"
           ></Column>
-          <Column field="created_at" header="Created" :sortable="true"></Column>
           <Column
-            class="timeCol"
-            field="updated_at"
-            header="Last Updated"
-            :sortable="true"
-          ></Column>
+            header="Created On"
+            filterField="created_at.long"
+            dataType="date"
+          >
+            <template #body="{ data }">
+              <p v-tooltip.top="data.created_at.long">
+                {{ data.created_at.short }}
+              </p>
+            </template>
+          </Column>
+          <Column header="Last Updated" filterField="date" dataType="date">
+            <template #body="{ data }">
+              <p v-tooltip.top="data.updated_at.long">
+                {{ data.updated_at.short }}
+              </p>
+            </template>
+          </Column>
           <Column
             field="id"
             header="Set Approval"

--- a/components/table/SearchBar.vue
+++ b/components/table/SearchBar.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+const props = defineProps({
+  searchTerm: [String, null],
+});
+
+const emit = defineEmits(["clearFilters", "updateSearch"]);
+
+const updatedGlobalSearchText = computed({
+  get() {
+    return props.searchTerm;
+  },
+  set(updatedSearchTerm: string) {
+    emit("updateSearch", updatedSearchTerm);
+  },
+});
+
+const clearFilters = () => {
+  emit("updateSearch", null);
+  emit("clearFilters");
+};
+</script>
+
+<template>
+  <div class="flex justify-content-end search-bar">
+    <div class="search-text-bar">
+      <IconField iconPosition="left">
+        <InputIcon>
+          <i class="pi pi-search" />
+        </InputIcon>
+        <InputText
+          v-model="updatedGlobalSearchText"
+          placeholder="Keyword Search"
+        />
+      </IconField>
+    </div>
+    <div class="search-clear-btn">
+      <Button
+        type="button"
+        icon="pi pi-filter-slash"
+        label="Clear"
+        v-tooltip.top="'Clear all filters'"
+        outlined
+        @click="clearFilters()"
+      />
+    </div>
+  </div>
+</template>
+
+<style></style>

--- a/utils/format-data-row.ts
+++ b/utils/format-data-row.ts
@@ -39,11 +39,19 @@ function parseUnixTimestamp(
         // If a UTC T/Z timestamp returned
         date = new Date(timestamp);
       }
-      dataRow[key] = date.toUTCString();
+      dataRow[key] = { short: formatDate(date), long: date.toUTCString() };
     }
   });
   return dataRow;
 }
+
+const formatDate = (value) => {
+  return value.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+};
 
 function isUnixTimestamp(value: number): boolean {
   // Unix timestamp should be a number and within reasonable range

--- a/utils/format-data-row.ts
+++ b/utils/format-data-row.ts
@@ -39,7 +39,11 @@ function parseUnixTimestamp(
         // If a UTC T/Z timestamp returned
         date = new Date(timestamp);
       }
-      dataRow[key] = { short: formatDate(date), long: date.toUTCString() };
+      dataRow[key] = {
+        short: formatDate(date),
+        long: date.toUTCString(),
+        date: date,
+      };
     }
   });
   return dataRow;


### PR DESCRIPTION
The following updates were made in this branch:

- Created and Updated datetimes were added back to the Analyses table
- Dates were converted to their shorter versions with a tooltip being added to the date cells to allow for the previous long version of the datetime to be seen
- The expand all button in the analyses table was refactored and fixed
- The `parseUnixTimestamp()` method now also returns the `Date()` object as well as the short and long strings of the date so that the `Date()` object can be used for filtering by calendar date ranges in the future if desired
- All date columns in all tables can now be sorted ascending/descending