### PR TITLE
105 manually check for running pods

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -3,7 +3,7 @@ name: Create and publish Docker image
 on:
   push:
     branches:
-      - "*"
+      - develop
   pull_request:
     types: [ "closed" ]
     branches:

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -3,7 +3,7 @@ name: Create and publish Docker image
 on:
   push:
     branches:
-      - develop
+      - "*"
   pull_request:
     types: [ "closed" ]
     branches:
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: contains(github.event.head_commit.message, 'build_image')
+    if: ${{ (github.event.pull_request.merged) || (contains(github.event.head_commit.message, 'build_image')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/components/analysis/AnalysisControlButtons.vue
+++ b/components/analysis/AnalysisControlButtons.vue
@@ -29,6 +29,7 @@ const stopButtonActiveStates = [
   AnalysisNodeRunStatus.Running,
   AnalysisNodeRunStatus.Starting,
   AnalysisNodeRunStatus.Started,
+  AnalysisNodeRunStatus.Stopping,
 ];
 const deleteButtonActiveStates = [
   AnalysisNodeRunStatus.Failed,
@@ -40,7 +41,12 @@ const deleteButtonActiveStates = [
   AnalysisNodeRunStatus.Started,
 ];
 
-const buttonStatuses = ref(setButtonStatuses(props.analysisRunStatus!));
+const buttonStatuses = ref(setButtonStatuses(props.analysisRunStatus));
+
+// TODO: possibly remove when manual pod status checks are removed
+watch(props, () => {
+  buttonStatuses.value = setButtonStatuses(props.analysisRunStatus);
+});
 
 function setButtonStatuses(podStatus: string) {
   emit("newRunStatus", props.analysisNodeId, podStatus);

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -23,7 +23,7 @@ export default defineNuxtPlugin(() => {
     },
     async onResponseError({ request, response }) {
       // Handle the response errors
-      if (response.status === 401 || response.status === 403) {
+      if (response.status === 401) {
         console.warn("User not signed in, returning to login");
         return login();
       }


### PR DESCRIPTION
The analysis table now manually checks with the PodOrc for each analysis whether any running pods exist and updates the control buttons and run status column accordingly. This will be removed in a future update once the PodOrc updates the hub with this information