### PR TITLE
chore(config): simplify nuxt config

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,25 +4,27 @@ website, the administrators have access to an overview of the submitted projects
 the data at the data center, as well as have full control over the individual containers running on their systems and 
 manage which projects/analyses have access to the various datasets.  
 
-## Needed `.env`
-This frontend requires the following environment variables to be set. While some appear as though they can be 
-auto-generated (e.g. the keycloak endpoints), they cannot be since the SSR framework used for this project (Nuxt) 
-requires the environment variable to be precisely named and explicitly defined in order to overwrite the 
-default configuration.
+## Required Environment Variables
+This frontend requires the following environment variables to be set. The SSR framework used for this project (Nuxt) 
+in addition to the OIDC library (nuxt-oidc-auth) requires the keycloak-related environment variables to be precisely 
+named and explicitly defined in order to overwrite the default configuration during runtime 
+(i.e. when deployed in a container).
 ```dotenv
 NUXT_PUBLIC_BASE_URL="http://localhost:3000"  # URL of the website
 NUXT_PUBLIC_HUB_ADAPTER_URL="http://urlForHubAdapterApi.de"  # URL for hub adapter API
 
+# Keycloak
 NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID="node-ui"
 NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET="someSecrets"
 
-# The following need to be explicitly set in order to apply them to the Nuxt config, they can't be built from the domain
+# The following need to be explicitly set in order to apply them to the Nuxt config, they can't be built from a 
+# base domain
 NUXT_OIDC_PROVIDERS_KEYCLOAK_REDIRECT_URI="http://localhost:3000/auth/keycloak/callback"  # Be sure this redirect URI is defined in your keycloak for this client
 NUXT_OIDC_PROVIDERS_KEYCLOAK_AUTHORIZATION_URL="https://my.keycloak.domain.de/realms/flame/protocol/openid-connect/auth"
 NUXT_OIDC_PROVIDERS_KEYCLOAK_TOKEN_URL="https://my.keycloak.domain.de/realms/flame/protocol/openid-connect/token"
 NUXT_OIDC_PROVIDERS_KEYCLOAK_USERINFO_URL="https://my.keycloak.domain.de/realms/flame/protocol/openid-connect/userinfo"
-NUXT_OIDC_PROVIDERS_KEYCLOAK_OPEN_ID_CONFIGURATION="http://my.keycloak.domain.de/realms/flame/.well-known/openid-configuration"
-NUXT_OIDC_PROVIDERS_KEYCLOAK_LOGOUT_URL="http://my.keycloak.domain.de/realms/flame/protocol/openid-connect/logout"
+NUXT_OIDC_PROVIDERS_KEYCLOAK_OPEN_ID_CONFIGURATION="https://my.keycloak.domain.de/realms/flame/.well-known/openid-configuration"
+NUXT_OIDC_PROVIDERS_KEYCLOAK_LOGOUT_URL="https://my.keycloak.domain.de/realms/flame/protocol/openid-connect/logout"
 NUXT_OIDC_PROVIDERS_KEYCLOAK_LOGOUT_REDIRECT_URI="http://localhost:3000"
 
 # Nuxt OIDC Tokens

--- a/components/KeycloakAuth.vue
+++ b/components/KeycloakAuth.vue
@@ -1,18 +1,12 @@
 <script setup lang="ts">
 const { loggedIn, user, login, logout } = useOidcAuth();
-
-async function customLogout() {
-  await logout();
-}
 </script>
 
 <template>
   <div class="keycloakLoginButton">
     <div v-if="loggedIn">
       <h3>Welcome {{ user.userInfo?.preferred_username || "Friend" }}!</h3>
-      <Button @click="customLogout()" severity="warning" outlined
-        >Logout</Button
-      >
+      <Button @click="logout()" severity="warning" outlined>Logout</Button>
     </div>
     <div v-else>
       <Button @click="login()" severity="success" outlined

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,35 +29,16 @@ export default defineNuxtConfig({
       keycloak: {
         audience: "account",
         userNameClaim: "preferred_username",
-        clientId:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_ID || "node-ui",
-        clientSecret: process.env
-          .NUXT_OIDC_PROVIDERS_KEYCLOAK_CLIENT_SECRET as string,
-        redirectUri:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_REDIRECT_URI ||
-          process.env.NUXT_PUBLIC_BASE_URL + "/auth/keycloak/callback",
-        authorizationUrl:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_AUTHORIZATION_URL ||
-          process.env.KEYCLOAK_LOGIN_URL +
-            "/realms/flame/protocol/openid-connect/auth",
-        tokenUrl:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_TOKEN_URL ||
-          process.env.KEYCLOAK_SERVICE_URL +
-            "/realms/flame/protocol/openid-connect/auth",
-        userinfoUrl:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_USERINFO_URL ||
-          process.env.KEYCLOAK_SERVICE_URL +
-            "/realms/flame/protocol/openid-connect/auth",
-        openIdConfiguration:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_OPEN_ID_CONFIGURATION ||
-          process.env.KEYCLOAK_SERVICE_URL +
-            "/realms/flame/.well-known/openid-configuration",
-        logoutUrl:
-          process.env.NUXT_OIDC_PROVIDERS_KEYCLOAK_LOGOUT_URL ||
-          process.env.KEYCLOAK_SERVICE_URL +
-            "/realms/flame/protocol/openid-connect/logout",
-        logoutRedirectUri: process.env.NUXT_PUBLIC_BASE_URL,
-        exposeAccessToken: true,
+        clientId: "",
+        clientSecret: "",
+        redirectUri: "",
+        authorizationUrl: "",
+        tokenUrl: "",
+        userinfoUrl: "",
+        openIdConfiguration: "",
+        logoutUrl: "",
+        logoutRedirectUri: "",
+        exposeAccessToken: false,
         pkce: false,
       },
     },


### PR DESCRIPTION
The `globalMiddlewareEnabled` option won't be used in order to allow the user to see the landing page first, and the config had the redundant env vars removed since they are added already so long as they are properly named. The README was updated to highlight this.