### PR TITLE
Add timeout request in case of misconfigured proxy

### DIFF
--- a/app/components/analysis/AnalysisControlButtons.vue
+++ b/app/components/analysis/AnalysisControlButtons.vue
@@ -231,6 +231,7 @@ async function onStartAnalysis() {
       useNuxtApp().$hubApi("/analysis/initialize", {
         method: "POST",
         body: analysisProps,
+        timeout: 0,
       }),
     ).catch((e) => {
       updatePodStatus(null);

--- a/app/components/analysis/AnalysisControlButtons.vue
+++ b/app/components/analysis/AnalysisControlButtons.vue
@@ -264,7 +264,11 @@ async function onStartAnalysis() {
     if (startPodResp && props.analysisId in startPodResp) {
       const currentExecutionStatus = startPodResp[props.analysisId];
       updatePodStatus(currentExecutionStatus);
-      showToast("success", "Start success", "Successfully started the container");
+      showToast(
+        "success",
+        "Start success",
+        "Successfully started the container",
+      );
     } else {
       updatePodStatus(originalExecutionStatus);
     }
@@ -283,19 +287,28 @@ async function onStopAnalysis() {
     const stopResp: StatusOnlyResponse = (await raceWithTimeout(
       useNuxtApp().$hubApi(`/po/stop/${props.analysisId}`, {
         method: "PUT",
+        timeout: 0,
       }),
     ).catch((e) => {
       if (e instanceof OperationTimeoutError) {
         showToast("error", "Stop failure", "The request timed out");
       } else {
-        showToast("error", "Stop failure", "Failed to stop the analysis container");
+        showToast(
+          "error",
+          "Stop failure",
+          "Failed to stop the analysis container",
+        );
       }
     })) as StatusOnlyResponse;
 
     // stopResp is undefined if error occurred
     if (stopResp) {
       if (props.analysisId in stopResp) {
-        showToast("success", "Stop success", "Successfully stopped the container");
+        showToast(
+          "success",
+          "Stop success",
+          "Successfully stopped the container",
+        );
       } else {
         // No pod statuses returned from PO for analysis
         showStatusUnknownToast();
@@ -318,19 +331,32 @@ async function onDeleteAnalysis() {
     const deleteResp: StatusOnlyResponse = (await raceWithTimeout(
       useNuxtApp().$hubApi(`/analysis/terminate/${props.analysisId}`, {
         method: "DELETE",
+        timeout: 0,
       }),
     ).catch((e) => {
       if (e instanceof OperationTimeoutError) {
-        showToast("error", "Terminate request failure", "The request timed out");
+        showToast(
+          "error",
+          "Terminate request failure",
+          "The request timed out",
+        );
       } else {
-        showToast("error", "Terminate request failure", "Failed to terminate the analysis");
+        showToast(
+          "error",
+          "Terminate request failure",
+          "Failed to terminate the analysis",
+        );
       }
     })) as StatusOnlyResponse;
 
     // deleteResp is undefined if error occurred
     if (deleteResp) {
       if (props.analysisId in deleteResp) {
-        showToast("success", "Delete success", "Successfully removed the container");
+        showToast(
+          "success",
+          "Delete success",
+          "Successfully removed the container",
+        );
       } else {
         showStatusUnknownToast();
       }

--- a/app/composables/connectionErrorToast.ts
+++ b/app/composables/connectionErrorToast.ts
@@ -63,6 +63,18 @@ export const showDownstreamConnectionErrorToast = (
   console.warn(`The ${service} service is unreachable`);
 };
 
+export const showProxyErrorToast = (toast: ToastServiceMethods) => {
+  showConnectionErrorToast(toast, {
+    severity: "error",
+    summary: "Connection error",
+    detail:
+      "Unable to contact the Hub, this is likely a proxy configuration issue",
+  });
+  console.warn(
+    "Hub is currently unreachable, likely due to proxy configuration",
+  );
+};
+
 // Kong error toasts
 
 export const showKongConnectionErrorToast = (toast: ToastServiceMethods) => {

--- a/app/plugins/api.ts
+++ b/app/plugins/api.ts
@@ -12,6 +12,7 @@ import {
   showKongMissingHealthConsumerErrorToast,
   showKongS3BucketErrorToast,
   showNotAuthenticatedToast,
+  showProxyErrorToast,
   showRbacPermissionError,
   showWrongRobotIdToast,
 } from "~/composables/connectionErrorToast";
@@ -40,6 +41,7 @@ export default defineNuxtPlugin(() => {
 
   const hubApi = $fetch.create({
     baseURL: baseUrl,
+    timeout: 30000,
     async onRequest({ options }) {
       const sessionData = await getSession();
 
@@ -64,6 +66,9 @@ export default defineNuxtPlugin(() => {
     },
     onRequestError({ error }) {
       console.error(error);
+      if (error.name === "TimeoutError" || error.name === "AbortError") {
+        showProxyErrorToast(toast);
+      }
     },
     async onResponseError({ request, response }) {
       // Handle the response errors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a specific connection-error toast that gives clearer guidance when requests fail due to likely proxy issues.

* **Bug Fixes**
  * Standardized request timeout behavior so long-running analysis operations now time out consistently (30s), routing timeout/abort failures through the improved error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->